### PR TITLE
Add unicode string support to Title and Description

### DIFF
--- a/djangojsonschema/jsonschema.py
+++ b/djangojsonschema/jsonschema.py
@@ -30,8 +30,8 @@ class DjangoFormToJSONSchema(object):
         #TODO detect bound field
         widget = field.widget
         target_def = {
-            'title': field.label or pretty_name(name),
-            'description': field.help_text,
+            'title': unicode(field.label) or pretty_name(name),
+            'description': unicode(field.help_text),
         }
         if field.required:
             target_def['required'] = [name] #TODO this likely is not correct


### PR DESCRIPTION
I found that in Django 1.8 unicode string fields (Title and Description) were coming out with the content:

```
django.utils.functional.__proxy__ object
```

Adding a unicode() wrapper around their definition fixes this
